### PR TITLE
Add missing dependencies for encryption

### DIFF
--- a/setup/deb/laps4linux-runner/DEBIAN/postinst
+++ b/setup/deb/laps4linux-runner/DEBIAN/postinst
@@ -7,4 +7,4 @@ set -e
 #. /usr/share/debconf/confmodule
 
 # we need the newest version from pyPI
-sudo -H pip3 install ldap3
+sudo -H pip3 install ldap3 dpapi-ng[kerberos]


### PR DESCRIPTION
dpapi-ng[kerberos] is missing for encrypted password storage with Windows LAPS in laps-runner