### PR TITLE
Fix incorrect filetime on encryptedpassword attribute

### DIFF
--- a/laps-runner/laps_runner/laps_runner.py
+++ b/laps-runner/laps_runner/laps_runner.py
@@ -249,7 +249,7 @@ class LapsRunner():
 		# 8-12 - blob size, uint32
 		# 12-16 - flags, currently always 0
 		preMagic = (
-			rotate_and_pack_msdatetime(dt_to_filetime(datetime.now()))
+			self.rotate_and_pack_msdatetime(dt_to_filetime(datetime.now()))
 			+ struct.pack('<i', len(encrypted))
 			+ b'\x00\x00\x00\x00'
 		)

--- a/laps-runner/laps_runner/laps_runner.py
+++ b/laps-runner/laps_runner/laps_runner.py
@@ -25,6 +25,12 @@ import logging
 import logging.handlers
 import traceback
 
+def rotate_and_pack_msdatetime(dt):
+	# MS AD uses upper time and lower time. The current ordering is backwards, which this fixes
+	# this can be seen by using dnSpy to trace attempts to get-lapsadpassword, which fail on validating the datetime.
+	left,right = struct.unpack('<LL',struct.pack('Q',dt))
+	packed = struct.pack('<LL',right,left)
+	return packed
 
 class LapsRunner():
 	server     = None
@@ -249,7 +255,7 @@ class LapsRunner():
 		# 8-12 - blob size, uint32
 		# 12-16 - flags, currently always 0
 		preMagic = (
-			struct.pack('<Q', dt_to_filetime(datetime.now()))
+			rotate_and_pack_msdatetime(dt_to_filetime(datetime.now()))
 			+ struct.pack('<i', len(encrypted))
 			+ b'\x00\x00\x00\x00'
 		)

--- a/laps-runner/laps_runner/laps_runner.py
+++ b/laps-runner/laps_runner/laps_runner.py
@@ -25,12 +25,6 @@ import logging
 import logging.handlers
 import traceback
 
-def rotate_and_pack_msdatetime(dt):
-	# MS AD uses upper time and lower time. The current ordering is backwards, which this fixes
-	# this can be seen by using dnSpy to trace attempts to get-lapsadpassword, which fail on validating the datetime.
-	left,right = struct.unpack('<LL',struct.pack('Q',dt))
-	packed = struct.pack('<LL',right,left)
-	return packed
 
 class LapsRunner():
 	server     = None
@@ -261,6 +255,13 @@ class LapsRunner():
 		)
 
 		return preMagic + encrypted
+
+	def rotate_and_pack_msdatetime(self, dt):
+		# MS AD uses upper time and lower time. The current ordering is backwards, which this fixes
+		# this can be seen by using dnSpy to trace attempts to get-lapsadpassword, which fail on validating the datetime.
+		left,right = struct.unpack('<LL',struct.pack('Q',dt))
+		packed = struct.pack('<LL',right,left)
+		return packed
 
 	def generatePassword(self):
 		return ''.join(secrets.choice(self.cfgAlphabet) for i in range(self.cfgLength))


### PR DESCRIPTION
Out of the box, get-lapsadpassword will fail on accounts that have used LAPS4Linux, even though the AD 'LAPS' page in dsa.msc will succeed.

This is because LAPS4Linux outputs an incorrect header on the mslaps-encryptedPassword attribute.
    
While the GUI does not seem to validate the filetime header, the powershell cmdlet decrypts the attribute to output information on the time the password was last set and runs into a type casting issue on the malformed header:

```
    Message        : Not a valid Win32 FileTime. (Parameter 'fileTime')
    ActualValue    :
    ParamName      : fileTime
    TargetSite     : System.DateTime FromFileTimeUtc(Int64)
    Data           : {}
    InnerException :
    HelpLink       :
    Source         : System.Private.CoreLib
    HResult        : -2146233086
    StackTrace     :    at System.DateTime.FromFileTimeUtc(Int64 fileTime)
                        at Microsoft.Windows.LAPS.EncryptedPasswordAttributePrefixInfo..ctor(UInt32 upperDateTimeStamp, UInt32 lowerDateTimeStamp, UInt32 encryptedBufferSize, UInt32 flagsReserved)
                        at Microsoft.Windows.LAPS.EncryptedPasswordAttributePrefixInfo.ParseFromBuffer(Byte[] buffer)
                        at Microsoft.Windows.LAPS.CmdletBase.ParseAndDecryptDirectoryPassword(IntPtr hDecryptionToken, Byte[] encryptedPasswordBytes, Boolean useRecoveryMode, Boolean useLocalKDS, DecryptionStatus& decryptionStatus)
                        at Microsoft.Windows.LAPS.GetLapsADPassword.BuildPasswordInfoFromEncryptedPassword(ComputerNameInfo computerNameInfo, PasswordSource passwordSource, Byte[] encryptedPassword, Nullable`1 passwordExpirationTimestampUTC, Boolean useRecoveryMode, Boolean
                    useLocalKDS)
                        at Microsoft.Windows.LAPS.GetLapsADPassword.ProcessOneIdentity(String Identity)
                        at Microsoft.Windows.LAPS.GetLapsADPassword.ProcessRecordInternal()
                        at Microsoft.Windows.LAPS.CmdletBase.ProcessRecord()
                        at System.Management.Automation.CommandProcessor.ProcessRecord()
```

This issue can be shown in powershell,  using DNSpy to debug lapspsh.dll (typically located at "C:\Windows\System32\WindowsPowerShell\v1.0\Modules\LAPS\lapspsh.dll"), setting breakpoints at:

 * Microsoft.Windows.LAPS.GetLapsAdPassword, Line 44 (`PasswordInfo passwordInfo = this.BuildPasswordInfoFromEncryptedPassword(computerNameInfo, PasswordSource.EncryptedPassword, passwordAttributes.EncryptedPassword, passwordExpirationTimestampUTC, this.RecoveryMode, useLocalKDS);`)
 * Microsoft.Windows.LAPS.EncryptedPasswordAttributePrefixInfo, Line 25
 * Microsoft.Windows.LAPS.EncryptedPasswordAttributePrefixInfo, Line 41:  
            `long fileTime = (long)EncryptedPasswordAttributePrefixInfo.ConvertTwoUIntsToULong(upperDateTimeStamp, lowerDateTimeStamp)`

Immediately prior to the exception, the two halves of the filetime can be seen in the locals window of dnSpy.
 * "Good" filetimes can be immediately decoded in powershell as `[datetime]::fromFileTimeUTC([long]0x<Upper><lower>)`.
 * "Bad" filetimes fail with a casting error, but can be decoded if their order is swapped.

Computer accounts with invalid headers from LAPS4Linux can be fixed with the [Powershell script provided here](https://github.com/schorschii/LAPS4LINUX/issues/34#issuecomment-2360989543).

Closes #34 