### PR TITLE
correct import of timezone

### DIFF
--- a/laps-runner/laps_runner/filetime.py
+++ b/laps-runner/laps_runner/filetime.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 # Microsoft Timestamp Conversion
@@ -15,4 +15,4 @@ def dt_to_filetime(dt):
 
 def filetime_to_dt(ft):
 	# ft is in UTC, fromtimestamp() converts to local time
-	return datetime.fromtimestamp(int((ft / HUNDREDS_OF_NANOSECONDS) - EPOCH_TIMESTAMP))
+	return datetime.fromtimestamp(int((ft / HUNDREDS_OF_NANOSECONDS) - EPOCH_TIMESTAMP), timezone.utc)

--- a/laps-runner/laps_runner/laps_runner.py
+++ b/laps-runner/laps_runner/laps_runner.py
@@ -174,7 +174,7 @@ class LapsRunner():
 		# generate new values
 		newPassword = self.generatePassword()
 		newPasswordHashed = CryptContext(schemes=["sha512_crypt"]).hash(newPassword)
-		newExpirationDate = datetime.now() + timedelta(days=self.cfgDaysValid)
+		newExpirationDate = datetime.now().astimezone(timezone.utc) + timedelta(days=self.cfgDaysValid)
 
 		# update in directory
 		self.setPasswordAndExpiry(newPassword, newExpirationDate)
@@ -212,7 +212,7 @@ class LapsRunner():
 			newPassword = json.dumps({
 				'p': newPassword,
 				'n': self.cfgUsername,
-				't': ('%0.2X' % dt_to_filetime(datetime.now())).lower()
+				't': ('%0.2X' % dt_to_filetime(datetime.now().astimezone(timezone.utc))).lower()
 			})
 
 		# encrypt Native LAPS content
@@ -285,7 +285,7 @@ class LapsRunner():
 		# 8-12 - blob size, uint32
 		# 12-16 - flags, currently always 0
 		preMagic = (
-			self.rotate_and_pack_msdatetime(dt_to_filetime(datetime.now()))
+			self.rotate_and_pack_msdatetime(dt_to_filetime(datetime.now().astimezone(timezone.utc)))
 			+ struct.pack('<i', len(encrypted))
 			+ b'\x00\x00\x00\x00'
 		)
@@ -382,7 +382,7 @@ def main():
 			runner.connectToServer()
 			runner.searchComputer()
 
-			if runner.tmpExpiryDate < datetime.now():
+			if runner.tmpExpiryDate < datetime.now().astimezone(timezone.utc):
 				print('Updating password (expired '+str(runner.tmpExpiryDate)+')')
 				runner.updatePassword()
 
@@ -402,7 +402,7 @@ def main():
 				if runner.cfgPamGracePeriod:
 					runner.logger.debug(__title__+': PAM grace period - waiting '+str(runner.cfgPamGracePeriod)+' seconds...')
 					# set expiration in directory, e.g. to handle reboots
-					runner.setExpiry(datetime.now() + timedelta(seconds=runner.cfgPamGracePeriod))
+					runner.setExpiry(datetime.now().astimezone(timezone.utc) + timedelta(seconds=runner.cfgPamGracePeriod))
 					# wait grace period
 					time.sleep(runner.cfgPamGracePeriod)
 				print('Updating password (forced update by PAM)...')

--- a/laps-runner/laps_runner/laps_runner.py
+++ b/laps-runner/laps_runner/laps_runner.py
@@ -6,7 +6,7 @@ from .filetime import dt_to_filetime, filetime_to_dt
 
 from pathlib import Path
 from os import path
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from dns import resolver, rdatatype
 from shutil import which
 from pid import PidFile, PidFileAlreadyLockedError, PidFileAlreadyRunningError
@@ -161,7 +161,7 @@ class LapsRunner():
 				self.tmpExpiryDate = filetime_to_dt( int(str(entry[self.cfgLdapAttributePasswordExpiry])) )
 			except Exception as e:
 				print('Unable to parse date '+str(self.tmpExpiry)+' - assuming that no expiration date is set.')
-				self.tmpExpiryDate = datetime.fromtimestamp(0, datetime.timezone.utc)
+				self.tmpExpiryDate = datetime.fromtimestamp(0, timezone.utc)
 			return True
 
 		# no result found


### PR DESCRIPTION
Fix: importing `timezone` correclty from the `datetime` package (instead of `datetime.datetime`)

The previous version lead to an unhandled `AttributeError` due to the faulty import. Mea culpa :raised_hands: 

Since the new `fromtimestamp(0, timestamp.utc)` method now returns a timezone-aware datetime object (confusingly enough, `utcfromtimestamp(0)` didn't), I went through the laps_runner.py and made all datetime objects "aware". We *could* also decide to make `self.tmpExpiryDate` "naive" instead (technically, this is the way it has been all along), but it might leave a timezone-switching user in a pickle. So I would recommend switching to aware objects at this point.