### PR TITLE
Documented a few undocumented features

### DIFF
--- a/laps-client/README.md
+++ b/laps-client/README.md
@@ -69,7 +69,7 @@ You can create a preset config file `/etc/laps-client.json` which will be loaded
   - `ldap-attribute-password-expiry`: The LDAP attribute name which contains the admin password expiration date. The client will write the updated expiration date into this attribute. Can also be a list of strings.
   - `ldap-attribute-password-history`: The LDAP attribute name which contains the admin password history. The client will try to decrypt this value (in case of Native LAPS) and use it to display the password history. Can also be a list of strings.
   - `connect-username`: The username which will be used for Remmina connections. May be modified by the client during the runtime since Native LAPS also stores username information.
-  - `use-autotype-enter`: Boolean, whether to automatically press enter after auto-typing the password.
+  - `use-autotype-enter`: Boolean, whether to use line break instead of tab character between username and password in autotype QR code.
 </details>
 
 If you want to view the DSRM password, simply put `msLAPS-EncryptedDSRMPassword` and `msLAPS-EncryptedDSRMPasswordHistory` into the `ldap-attributes` and `ldap-attribute-password`|`ldap-attribute-password-history` configuration.

--- a/laps-client/README.md
+++ b/laps-client/README.md
@@ -69,6 +69,7 @@ You can create a preset config file `/etc/laps-client.json` which will be loaded
   - `ldap-attribute-password-expiry`: The LDAP attribute name which contains the admin password expiration date. The client will write the updated expiration date into this attribute. Can also be a list of strings.
   - `ldap-attribute-password-history`: The LDAP attribute name which contains the admin password history. The client will try to decrypt this value (in case of Native LAPS) and use it to display the password history. Can also be a list of strings.
   - `connect-username`: The username which will be used for Remmina connections. May be modified by the client during the runtime since Native LAPS also stores username information.
+  - `use-autotype-enter`: Boolean, whether to automatically press enter after auto-typing the password.
 </details>
 
 If you want to view the DSRM password, simply put `msLAPS-EncryptedDSRMPassword` and `msLAPS-EncryptedDSRMPasswordHistory` into the `ldap-attributes` and `ldap-attribute-password`|`ldap-attribute-password-history` configuration.

--- a/laps-runner/README.md
+++ b/laps-runner/README.md
@@ -45,6 +45,8 @@ Please configure the runner by editing the configuration file `/etc/laps-runner.
   - `password-length`: Determines how long a generated password should be.
   - `password-alphabet`: Determines the chars to use for password generation. Can be either just a character string or a list of character strings. In the latter case, the password contains at least one character from each string.
   - `hooks`: Dict of commands to execute after password change. The dict key should be a string (displayed in log output) and the value should be an array of parameters. Parameter `$PASSWORD$` and `$USERNAME$` will be replaced accordingly. Have a look at the sample config file for example hooks. You can use this feature to align other passwords with the local admin/root, e.g. your BIOS/UEFI password or the password of local database admin accounts.
+  - `pam-services`: Array of PAM service names to trigger password rotation.
+  - `pam-grace-period`: Grace period in seconds after logout until password rotation.
 
 Important:
 - If `native-laps` is `false`, you should set `ldap-attribute-password` to `ms-Mcs-AdmPwd` and `ldap-attribute-password-expiry` to `ms-Mcs-AdmPwdExpirationTime`.

--- a/laps-runner/README.md
+++ b/laps-runner/README.md
@@ -45,8 +45,8 @@ Please configure the runner by editing the configuration file `/etc/laps-runner.
   - `password-length`: Determines how long a generated password should be.
   - `password-alphabet`: Determines the chars to use for password generation. Can be either just a character string or a list of character strings. In the latter case, the password contains at least one character from each string.
   - `hooks`: Dict of commands to execute after password change. The dict key should be a string (displayed in log output) and the value should be an array of parameters. Parameter `$PASSWORD$` and `$USERNAME$` will be replaced accordingly. Have a look at the sample config file for example hooks. You can use this feature to align other passwords with the local admin/root, e.g. your BIOS/UEFI password or the password of local database admin accounts.
-  - `pam-services`: Array of PAM service names to trigger password rotation.
-  - `pam-grace-period`: Grace period in seconds after logout until password rotation.
+  - `pam-services`: Array of PAM service names to trigger password rotation (see section "Automatically Rotate Password After Logout" for more info).
+  - `pam-grace-period`: Grace period in seconds after PAM event (e.g. login, logout) until password rotation.
 
 Important:
 - If `native-laps` is `false`, you should set `ldap-attribute-password` to `ms-Mcs-AdmPwd` and `ldap-attribute-password-expiry` to `ms-Mcs-AdmPwdExpirationTime`.


### PR DESCRIPTION
These features:
`use-autotype-enter`
`pam-services`
`pam-grace-period`

Were undocumented in README. They do show up in JSON configs though.